### PR TITLE
feat: add ovh-prod environment and manual prod deploy workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,35 @@
+name: Deploy to prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g. 1.7.6). See "List available versions" job for recent tags'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  list_versions:
+    name: List available versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Recent tags
+        run: |
+          echo "## Recent portal versions (last 10 git tags):"
+          git tag -l --sort=-v:refname | head -10
+
+  deploy_prod:
+    name: Deploy portal ${{ inputs.version }}-ovh-prod
+    needs: [list_versions]
+    uses: PilotDataPlatform/pilot-hdc-ci-tools/.github/workflows/update_gitops_versions.yml@main
+    with:
+      service_key: portal
+      image_tag: ${{ inputs.version }}-ovh-prod
+      environment: prod
+    secrets: inherit

--- a/.github/workflows/hdc-pipeline.yml
+++ b/.github/workflows/hdc-pipeline.yml
@@ -75,7 +75,7 @@ jobs:
 
     strategy:
       matrix:
-        environment: ["hdc-dev","hdc-prod","hdc-lite","ovh-dev"]
+        environment: ["hdc-dev","hdc-prod","hdc-lite","ovh-dev","ovh-prod"]
 
     environment: ${{ matrix.environment }}
 
@@ -96,6 +96,8 @@ jobs:
             MATRIX_ENV="lite"
           elif [[ "${{ matrix.environment }}" == "ovh-dev" ]]; then
             MATRIX_ENV="ovh-dev"
+          elif [[ "${{ matrix.environment }}" == "ovh-prod" ]]; then
+            MATRIX_ENV="ovh-prod"
           else
             echo "Unsupported environment: ${{ matrix.environment }}"
             exit 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal",
-  "version": "1.7.6-hdc",
+  "version": "1.7.7-hdc",
   "displayVersion": "1.6.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add `ovh-prod` to the build matrix in `hdc-pipeline.yml` so CI produces `<version>-ovh-prod` images
- New `deploy-prod.yml` workflow triggered via `workflow_dispatch` for manual prod deployments
- Version bump to 1.7.7-hdc

## Test plan
- [ ] Verify `ovh-prod` GitHub Environment exists with required secrets/vars
- [ ] Trigger CI on main — confirm `ovh-prod` matrix job builds successfully
- [ ] Trigger "Deploy to prod" manually — confirm gitops `versions.yaml` gets bumped